### PR TITLE
Adding a line in the readme to fix free drawing not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ const fabricOverlay = newViewer.fabricOverlay({
 
 //Needs to be set to false to disable default mouse navigation in OSD.
 newViewer.setMouseNavEnabled(false);
-newViewer.outerTracker.setTracking(false);
 
 fabricOverlay.fabricCanvas().freeDrawingBrush = new fabric.PencilBrush(fabricOverlay.fabricCanvas());
 fabricOverlay.fabricCanvas().freeDrawingBrush.width = 15;

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ const fabricOverlay = newViewer.fabricOverlay({
       fabricCanvasOptions: { selection: false },
     });
 
+//Needs to be set to false to disable default mouse navigation in OSD.
+newViewer.setMouseNavEnabled(false);
+newViewer.outerTracker.setTracking(false);
+
 fabricOverlay.fabricCanvas().freeDrawingBrush = new fabric.PencilBrush(fabricOverlay.fabricCanvas());
 fabricOverlay.fabricCanvas().freeDrawingBrush.width = 15;
 fabricOverlay.fabricCanvas().freeDrawingBrush.color = selectedColor;


### PR DESCRIPTION
While using this plugin for OpenSeadragon I discovered the free drawing does not work unless OSD's mouse navigation is disabled. I thought having this written in the readme might help others from encountering this issue.