### PR TITLE
Fix Fabric 6+ Compatibility and Typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+.idea

--- a/lib/openseadragon-fabric.d.ts
+++ b/lib/openseadragon-fabric.d.ts
@@ -1,16 +1,16 @@
 import { FabricOverlay, FabricOverlayConfig } from './fabric-canvas';
-import { FabricObject } from 'fabric';
+import { FabricObject, TPointerEvent, StaticCanvasEvents } from 'fabric';
 declare module 'openseadragon' {
     interface Viewer {
         fabricOverlay: (props: FabricOverlayConfig) => FabricOverlay;
     }
 }
 declare module 'fabric' {
-    interface StaticCanvas {
-        setActiveObject: (object: FabricObject) => void;
+    interface StaticCanvas<EventSpec extends StaticCanvasEvents = StaticCanvasEvents> {
+        setActiveObject(object: FabricObject, e?: TPointerEvent): boolean;
     }
-    interface Canvas {
-        setActiveObject: (object: FabricObject) => boolean;
+    interface Canvas<EventSpec = any> {
+        setActiveObject(object: FabricObject, e?: TPointerEvent): boolean;
     }
 }
 declare function initOSDFabricJS(): void;

--- a/src/openseadragon-fabric.ts
+++ b/src/openseadragon-fabric.ts
@@ -1,6 +1,11 @@
 import OpenSeadragon from 'openseadragon';
 import { FabricOverlay, FabricOverlayConfig } from './fabric-canvas';
-import { FabricObject, Canvas } from 'fabric';
+import {
+  FabricObject,
+  Canvas,
+  TPointerEvent,
+  StaticCanvasEvents,
+} from 'fabric';
 declare module 'openseadragon' {
   interface Viewer {
     fabricOverlay: (props: FabricOverlayConfig) => FabricOverlay;
@@ -8,11 +13,13 @@ declare module 'openseadragon' {
 }
 
 declare module 'fabric' {
-  interface StaticCanvas {
-    setActiveObject: (object: FabricObject) => void;
+  interface StaticCanvas<
+    EventSpec extends StaticCanvasEvents = StaticCanvasEvents
+  > {
+    setActiveObject(object: FabricObject, e?: TPointerEvent): boolean;
   }
-  interface Canvas {
-    setActiveObject: (object: FabricObject) => boolean;
+  interface Canvas<EventSpec = any> {
+    setActiveObject(object: FabricObject, e?: TPointerEvent): boolean;
   }
 }
 


### PR DESCRIPTION
* Updated `setActiveObject` typings on `StaticCanvas` and `Canvas` to match **Fabric 6.7.1**, fixing TS compilation errors.
* Ensures plugin works with Angular/ESM projects using Fabric 6+.
* No breaking changes for Fabric 6 users.

Closes: #7 
